### PR TITLE
Fix sorting values

### DIFF
--- a/MMM-VigiCrues.js
+++ b/MMM-VigiCrues.js
@@ -313,7 +313,7 @@ Module.register("MMM-VigiCrues",{
 		}
 
 		this.config.alertTable.sort((a, b) => Number(a.value) - Number(b.value));
-		data.data.sort((a, b) => moment(a.date_obs).diff(moment(b.date_obs)));
+		data.data.sort((a, b) => moment(b.date_obs).diff(moment(a.date_obs)));
 
 		this.levelCurrent = this.roundValue(data.data[0].resultat_obs / 1000, 2);
 


### PR DESCRIPTION
Hi,

My charts were displaying value from last month:

![error](https://user-images.githubusercontent.com/56997295/147662460-dab6a19f-a1fe-4672-b0cb-9b37ba7e8a10.png)

The data received from the API were sorted but the most recent value at the end. The current level and the chart was incorrect.
I inverted the sorting function. Now the most recent value is on first position in the data array.

The chart and level value are ok now:

![corrected](https://user-images.githubusercontent.com/56997295/147662759-4ca84565-ebe4-4cf2-88b1-8b83b4eaefce.png)

